### PR TITLE
Updates for autodoc

### DIFF
--- a/docs/apidoc.rst
+++ b/docs/apidoc.rst
@@ -3,7 +3,8 @@ LiCSAR proc
 
 LiCSAR unwrapping module
 ^^^^^^^^^^^^^^^^^^^^^^^^
-:ref:`apidoc_unwrap`
+
+.. _apidoc_unwrap:
 
 Here we document the python tool ``lics_unwrap.py``. Note this is early attempt for the documentation.
 

--- a/docs/apidoc.rst
+++ b/docs/apidoc.rst
@@ -2,7 +2,7 @@ LiCSAR proc
 ===========
 
 LiCSAR unwrapping module
-^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^
 :ref:`apidoc_unwrap`
 
 Here we document the python tool ``lics_unwrap.py``. Note this is early attempt for the documentation.

--- a/docs/apidoc.rst
+++ b/docs/apidoc.rst
@@ -8,5 +8,5 @@ LiCSAR unwrapping module
 
 Here we document the python tool ``lics_unwrap.py``. Note this is early attempt for the documentation.
 
-.. automodule:: python.LiCSAR_lib.lics_unwrap
+.. automodule:: licsar_proc.python.LiCSAR_lib.lics_unwrap
   :members:


### PR DESCRIPTION
There was a '^' missing under a title.

I _think_ the :ref: should be a custom anchor? (useful reference: https://sublime-and-sphinx-guide.readthedocs.io/en/latest/references.html).

Use full path for autodoc. The Python path for Sphinx is set in the main conf.py.